### PR TITLE
Allow for nil returns

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -39,6 +39,14 @@ func init() {
 	case "bolt":
 		store, err = storage.Bolt(os.Getenv("BOLTDB_FILE_PATH"))
 
+	case "dynamodb":
+		secret := os.Getenv("AWS_SECRET_KEY")
+		access := os.Getenv("AWS_ACCESS_KEY")
+		region := os.Getenv("AWS_REGION")
+		table := os.Getenv("DYNAMODB_TABLE")
+
+		store, err = storage.DynamoDB(access, secret, region, table)
+
 	default:
 		store = storage.Local()
 	}
@@ -60,6 +68,11 @@ func main() {
 	}
 
 	data := store.Get("name") // []byte("John Doe")
+
+	if data == nil {
+		fmt.Println("Missing key: name")
+		return
+	}
 
 	fmt.Printf("Hello, %s.\n", data) // Hello, John Doe.
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/kyani-inc/storage.v1"
+	"github.com/kyani-inc/storage"
 )
 
 var store storage.Storage

--- a/providers/dynamodb/dynamodb.go
+++ b/providers/dynamodb/dynamodb.go
@@ -70,13 +70,13 @@ func (ddb DynamoDB) Get(key string) []byte {
 	results, err := ddb.Conn.GetItem(params)
 
 	if err != nil {
-		return []byte{}
+		return nil
 	}
 
 	if val, ok := results.Item["value"]; ok {
 		return val.B
 	}
-	return []byte{}
+	return nil
 }
 
 // Delete removes a file by key.

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -65,18 +65,18 @@ func (store S3) Put(key string, data []byte) error {
 
 // Get attempts to access the contents of a file by key.
 func (store S3) Get(key string) []byte {
-	b := []byte{}
+	var b []byte
 
 	bucket, err := store.remoteBucket()
 
 	if err != nil {
-		return []byte{}
+		return b
 	}
 
 	b, err = bucket.Get(store.uri(key))
 
 	if err != nil {
-		return []byte{}
+		return nil
 	}
 
 	return b
@@ -154,4 +154,3 @@ func (store S3) validate() error {
 
 	return errors.New(fmt.Sprintf("S3 errors %+v", errs))
 }
-

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ Unified key/value storage interface for several backing technologies.
 - **Memcached** ([Memcached](http://memcached.org/) backed store; production ready)
 - **Redis** ([Redis](http://redis.io/) backed store; production ready)
 - **S3** ([AWS S3](https://aws.amazon.com/s3/) backed store; production ready)
+- **DynamoDB** (AWS DynamoDB)[https://aws.amazon.com/dynamodb/] backed store; production ready)
 - **Folder** (local folder backed store; intended for dev)
 - **Local** (application's memory backed store; intended for dev)
 
@@ -59,6 +60,14 @@ func init() {
 	case "bolt":
 		store, err = storage.Bolt(os.Getenv("BOLTDB_FILE_PATH"))
 
+	case "dynamodb":
+		secret := os.Getenv("AWS_SECRET_KEY")
+		access := os.Getenv("AWS_ACCESS_KEY")
+		region := os.Getenv("AWS_REGION")
+		table := os.Getenv("DYNAMODB_TABLE")
+
+		store, err = storage.DynamoDB(access, secret, region, table)
+
 	default:
 		store = storage.Local()
 	}
@@ -81,6 +90,11 @@ func main() {
 
 	data := store.Get("name") // []byte("John Doe")
 
+	if data == nil {
+		fmt.Println("Missing key: name");
+		return
+	}
+
 	fmt.Printf("Hello, %s.\n", data) // Hello, John Doe.
 
 	store.Delete("name") // remove "name"
@@ -99,7 +113,7 @@ To test certain drivers you will need to provide the services to test against. T
 [gotenv](https://github.com/subosito/gotenv) so that you can provide environment variables for the tests.
 Otherwise tests that require these variables will be skipped.
 
-For example: Testing the Redis implementation on your local machine would require the file `internal/redis/.env` with the following
+For example: Testing the Redis implementation on your local machine would require the file `providers/redis/.env` with the following
 contents (replace HOST and PORT with your values).
 
 ```

--- a/storage.go
+++ b/storage.go
@@ -13,7 +13,7 @@ import (
 
 // Storage represents a storage facility agnostic of the backing technology.
 type Storage interface {
-	// Get returns data by key. Missing keys return empty []byte.
+	// Get returns data by key. Missing keys return `nil`.
 	Get(key string) []byte
 
 	// Put will overwrite data by key.


### PR DESCRIPTION
All but two of our providers had the potential to return nil for missing values. S3 and DynamoDB always returned an empty `[]byte` which is not nil. 
